### PR TITLE
chore: bump to v0.20.1, update author email

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "gainlineup"
-version = "0.20.0"
+version = "0.20.1"
 dependencies = [
  "rfconversions",
  "serde",
@@ -54,9 +54,9 @@ dependencies = [
 
 [[package]]
 name = "rfconversions"
-version = "0.5.1"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d175bbaec53e5189ddf3dd9ec9e17ee73d0727acfaa4b07197dde295bb44353"
+checksum = "360d2e51a74ba62e9ae05960bf4af0f2d968adfab9d4f5217da8c3d97dd3992a"
 
 [[package]]
 name = "serde"
@@ -149,9 +149,9 @@ checksum = "df8b2b54733674ad286d16267dcfc7a71ed5c776e4ac7aa3c3e2561f7c637bf2"
 
 [[package]]
 name = "touchstone"
-version = "0.10.4"
+version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d13dbdc99255bc8fb18fbf9398ad3912ce472de62e77f97a2662f4a42a94f293"
+checksum = "f0a6176546c3d5094fccf8f4fe846293d5a3dd8f73df213554d3ff5f2c7a7ad6"
 dependencies = [
  "rfconversions",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-authors = ["Ian Cleary <rust@iancleary.me>"]
+authors = ["Ian Cleary <iancleary@hey.com>"]
 description = "A Gain Lineup toolbox for RF Modeling"
 documentation = "https://docs.rs/gainlineup"
 edition = "2021"
@@ -7,15 +7,15 @@ homepage = "https://github.com/iancleary/gainlineup"
 license = "MIT"
 name = "gainlineup"
 repository = "https://github.com/iancleary/gainlineup"
-version = "0.20.0"
+version = "0.20.1"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-rfconversions = "0.5.1"
+rfconversions = "0.6.0"
 serde = { version = "1.0", features = ["derive"] }
 toml = "0.9.8"
-touchstone = "0.10.4"
+touchstone = "0.11.2"
 
 [features]
 default = ["cli", "plot"]


### PR DESCRIPTION
- Bump version 0.20.0 → 0.20.1
- Update author email to iancleary@hey.com
- 102 tests, all passing