### PR TITLE
rustdoc: add #[must_use], #[doc(alias)], #[warn(missing_docs)]

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "gainlineup"
-version = "0.20.1"
+version = "0.20.2"
 dependencies = [
  "rfconversions",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ homepage = "https://github.com/iancleary/gainlineup"
 license = "MIT"
 name = "gainlineup"
 repository = "https://github.com/iancleary/gainlineup"
-version = "0.20.1"
+version = "0.20.2"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/src/amplifier_model.rs
+++ b/src/amplifier_model.rs
@@ -22,6 +22,8 @@ use crate::block::Block;
 /// assert!((point.input_dbm - (-30.0)).abs() < 0.01);
 /// assert!((point.gain_db - 20.0).abs() < 0.01);
 /// ```
+#[doc(alias = "AM-AM")]
+#[doc(alias = "AM-PM")]
 #[derive(Clone, Debug)]
 pub struct AmplifierPoint {
     /// Input power (dBm).
@@ -71,6 +73,9 @@ impl fmt::Display for AmplifierPoint {
 /// let phase = model.phase_shift_at(0.0).unwrap();
 /// assert!(phase >= 0.0);
 /// ```
+#[doc(alias = "amplifier")]
+#[doc(alias = "PA")]
+#[doc(alias = "power amplifier")]
 #[derive(Clone, Debug)]
 pub struct AmplifierModel<'a> {
     /// The underlying block with gain, NF, P1dB, and IP3.
@@ -99,6 +104,7 @@ impl<'a> AmplifierModel<'a> {
     /// let model = AmplifierModel::new(&block);
     /// assert!(model.phase_shift_at(-30.0).is_none());
     /// ```
+    #[must_use]
     pub fn new(block: &'a Block) -> Self {
         Self {
             block,
@@ -126,6 +132,7 @@ impl<'a> AmplifierModel<'a> {
     /// let phase = model.phase_shift_at(10.0).unwrap();
     /// assert!((phase - 0.0).abs() < 1e-10);
     /// ```
+    #[must_use]
     pub fn with_am_pm(block: &'a Block, coeff_deg_per_db: f64) -> Self {
         Self {
             block,
@@ -151,6 +158,7 @@ impl<'a> AmplifierModel<'a> {
     /// let model = AmplifierModel::with_saturation(&block, 35.0);
     /// assert_eq!(model.saturation_power_dbm, Some(35.0));
     /// ```
+    #[must_use]
     pub fn with_saturation(block: &'a Block, psat_dbm: f64) -> Self {
         Self {
             block,
@@ -179,6 +187,7 @@ impl<'a> AmplifierModel<'a> {
     ///     .build();
     /// assert_eq!(model.saturation_power_dbm, Some(37.0));
     /// ```
+    #[must_use]
     pub fn builder(block: &'a Block) -> AmplifierModelBuilder<'a> {
         AmplifierModelBuilder {
             block,
@@ -218,6 +227,7 @@ impl<'a> AmplifierModel<'a> {
     /// let phase = model.phase_shift_at(-5.0).unwrap();
     /// assert!((phase - 50.0).abs() < 1e-10);
     /// ```
+    #[must_use]
     pub fn phase_shift_at(&self, input_power_dbm: f64) -> Option<f64> {
         let coeff = self.am_pm_coefficient_deg_per_db?;
         let input_p1db = self.input_p1db_dbm()?;
@@ -248,6 +258,7 @@ impl<'a> AmplifierModel<'a> {
     /// let sweep = model.am_am_am_pm_sweep(-40.0, -20.0, 5.0);
     /// assert_eq!(sweep.len(), 5);
     /// ```
+    #[must_use]
     pub fn am_am_am_pm_sweep(
         &self,
         start_dbm: f64,
@@ -297,6 +308,7 @@ impl<'a> AmplifierModel<'a> {
     /// let backoff = model.backoff_for_target_phase(5.0).unwrap();
     /// assert!((backoff - (-0.5)).abs() < 1e-10);
     /// ```
+    #[must_use]
     pub fn backoff_for_target_phase(&self, max_phase_deg: f64) -> Option<f64> {
         let coeff = self.am_pm_coefficient_deg_per_db?;
         if coeff == 0.0 {
@@ -335,6 +347,7 @@ impl<'a> AmplifierModel<'a> {
     /// let evm = model.evm_from_am_pm(-50.0).unwrap();
     /// assert!(evm < 0.001);
     /// ```
+    #[must_use]
     pub fn evm_from_am_pm(&self, input_power_dbm: f64) -> Option<f64> {
         let phase_deg = self.phase_shift_at(input_power_dbm)?;
         let phase_rad = phase_deg.to_radians();
@@ -389,6 +402,7 @@ impl<'a> AmplifierModelBuilder<'a> {
     ///     .build();
     /// assert_eq!(model.am_pm_coefficient_deg_per_db, Some(5.0));
     /// ```
+    #[must_use]
     pub fn am_pm_coefficient(mut self, coeff_deg_per_db: f64) -> Self {
         self.am_pm_coefficient_deg_per_db = Some(coeff_deg_per_db);
         self
@@ -413,6 +427,7 @@ impl<'a> AmplifierModelBuilder<'a> {
     ///     .build();
     /// assert_eq!(model.saturation_power_dbm, Some(35.0));
     /// ```
+    #[must_use]
     pub fn saturation_power(mut self, psat_dbm: f64) -> Self {
         self.saturation_power_dbm = Some(psat_dbm);
         self
@@ -435,6 +450,7 @@ impl<'a> AmplifierModelBuilder<'a> {
     /// let model = AmplifierModel::builder(&block).build();
     /// assert!(model.am_pm_coefficient_deg_per_db.is_none());
     /// ```
+    #[must_use]
     pub fn build(self) -> AmplifierModel<'a> {
         AmplifierModel {
             block: self.block,

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -1,1 +1,2 @@
+/// Boltzmann constant in J/K (SI units).
 pub const BOLTZMANN: f64 = 1.380649e-23;

--- a/src/input.rs
+++ b/src/input.rs
@@ -24,12 +24,18 @@ use crate::node::SignalNode;
 ///     noise_temperature_k: Some(270.0),
 /// };
 /// ```
+#[doc(alias = "signal")]
+#[doc(alias = "input power")]
 #[derive(Clone, Debug)]
 pub struct Input {
-    pub frequency_hz: f64,                // Hz, center frequency of signal
-    pub bandwidth_hz: f64,                // Hz, width of signal
-    pub power_dbm: f64,                   // dBm, power of signal
-    pub noise_temperature_k: Option<f64>, // K, noise temperature of signal
+    /// Center frequency of the input signal in Hz.
+    pub frequency_hz: f64,
+    /// Bandwidth of the input signal in Hz.
+    pub bandwidth_hz: f64,
+    /// Input signal power in dBm.
+    pub power_dbm: f64,
+    /// Noise temperature of the input in Kelvin (defaults to 270 K if `None`).
+    pub noise_temperature_k: Option<f64>,
 }
 
 impl fmt::Display for Input {
@@ -66,6 +72,7 @@ impl Input {
     /// assert_eq!(input.frequency_hz, 2.4e9);
     /// assert_eq!(input.bandwidth_hz, 20.0e6);
     /// ```
+    #[must_use]
     pub fn new(
         frequency_hz: f64,
         bandwidth_hz: f64,
@@ -91,6 +98,7 @@ impl Input {
     /// let nsd = input.noise_spectral_density();
     /// assert!((nsd - (-174.0)).abs() < 0.1); // ~-174 dBm/Hz at 290 K
     /// ```
+    #[must_use]
     pub fn noise_spectral_density(&self) -> f64 {
         let k = constants::BOLTZMANN;
         let t = self.noise_temperature_k.unwrap_or(270.0);
@@ -123,6 +131,7 @@ impl Input {
     /// // kTB at 290K, 1 MHz ≈ -114 dBm
     /// assert!((noise - (-114.0)).abs() < 0.1);
     /// ```
+    #[must_use]
     pub fn noise_power(&self) -> f64 {
         let k = constants::BOLTZMANN;
         let t = self.noise_temperature_k.unwrap_or(270.0);
@@ -158,6 +167,7 @@ impl Input {
     /// assert_eq!(output.signal_power_dbm, 0.0); // -30 + 30 = 0 dBm
     /// assert_eq!(output.name, "LNA Output");
     /// ```
+    #[must_use]
     pub fn cascade_block(&self, block: &Block) -> SignalNode {
         #[cfg(feature = "debug-print")]
         println!("Start INPUT");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,36 @@
+#![warn(missing_docs)]
+//! # gainlineup
+//!
+//! A gain lineup toolbox for RF cascade analysis and signal chain modeling.
+//!
+//! This crate provides types and functions for computing cascaded gain, noise figure,
+//! IP3, dynamic range, and compression through a chain of RF blocks (amplifiers,
+//! attenuators, filters, mixers, etc.).
+//!
+//! # Quick Start
+//!
+//! ```
+//! use gainlineup::{Input, Block, cascade_vector_return_output};
+//!
+//! let input = Input::new(1.0e9, 1.0e6, -30.0, Some(270.0));
+//! let blocks = vec![
+//!     Block {
+//!         name: "LNA".to_string(),
+//!         gain_db: 30.0,
+//!         noise_figure_db: 1.5,
+//!         output_p1db_dbm: None,
+//!         output_ip3_dbm: None,
+//!     },
+//! ];
+//! let output = cascade_vector_return_output(input, blocks);
+//! assert_eq!(output.signal_power_dbm, 0.0);
+//! ```
+
 mod block;
 
+/// Command-line interface for the gainlineup tool.
 #[cfg(feature = "cli")]
+#[allow(missing_docs)]
 pub mod cli;
 mod constants;
 mod file_operations;
@@ -46,6 +76,10 @@ pub use node::{DynamicRange, SignalNode};
 /// assert_eq!(output.signal_power_dbm, -6.0); // -30 + 30 - 6
 /// assert_eq!(output.cumulative_gain_db, 24.0);
 /// ```
+#[doc(alias = "cascade")]
+#[doc(alias = "signal chain")]
+#[doc(alias = "gain lineup")]
+#[must_use]
 pub fn cascade_vector_return_output(input: Input, blocks: Vec<Block>) -> SignalNode {
     let mut cascading_signal: SignalNode = SignalNode::default(); // will be overwritten in first iteration
 
@@ -89,6 +123,9 @@ pub fn cascade_vector_return_output(input: Input, blocks: Vec<Block>) -> SignalN
 /// assert_eq!(nodes[0].signal_power_dbm, 0.0);  // after LNA
 /// assert_eq!(nodes[1].signal_power_dbm, -3.0);  // after filter
 /// ```
+#[doc(alias = "cascade")]
+#[doc(alias = "signal chain")]
+#[must_use]
 pub fn cascade_vector_return_vector(input: Input, blocks: Vec<Block>) -> Vec<SignalNode> {
     let mut cascading_signal: SignalNode = SignalNode::default(); // will be overwritten in first iteration
 
@@ -128,6 +165,9 @@ pub fn cascade_vector_return_vector(input: Input, blocks: Vec<Block>) -> Vec<Sig
 /// assert_eq!(sweep.len(), 3);
 /// assert!((sweep[0].1 - (-20.0)).abs() < 0.01); // -40 + 20 = -20 (linear)
 /// ```
+#[doc(alias = "P1dB")]
+#[doc(alias = "compression")]
+#[must_use]
 pub fn cascade_am_am_sweep(
     blocks: &[Block],
     start_dbm: f64,
@@ -174,6 +214,8 @@ pub fn cascade_am_am_sweep(
 /// assert!((sweep[0].1 - 20.0).abs() < 0.01); // full gain at low power
 /// assert!(sweep.last().unwrap().1 < 20.0);    // compressed at high power
 /// ```
+#[doc(alias = "gain compression")]
+#[must_use]
 pub fn cascade_gain_compression_sweep(
     blocks: &[Block],
     start_dbm: f64,


### PR DESCRIPTION
Patch version bump 0.20.1 → 0.20.2

- `#![warn(missing_docs)]` + crate/module doc comments
- `#[must_use]` on all 30+ pub fns returning values
- `#[doc(alias)]` for RF terms (cascade, NF, P1dB, IMD3, dynamic range, etc.)
- Doc comments on all pub struct fields (Block, SignalNode, Input)
- All 50 tests pass, clippy clean