### PR TITLE
chore: bump rfconversions to 0.7.0, touchstone to 0.11.4, version to 0.20.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "gainlineup"
-version = "0.20.2"
+version = "0.20.3"
 dependencies = [
  "rfconversions",
  "serde",
@@ -54,9 +54,9 @@ dependencies = [
 
 [[package]]
 name = "rfconversions"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "360d2e51a74ba62e9ae05960bf4af0f2d968adfab9d4f5217da8c3d97dd3992a"
+checksum = "69516f3a14063db1538c3694768b4091b627a4474ba066565e4de00ea8292aad"
 
 [[package]]
 name = "serde"
@@ -149,9 +149,9 @@ checksum = "df8b2b54733674ad286d16267dcfc7a71ed5c776e4ac7aa3c3e2561f7c637bf2"
 
 [[package]]
 name = "touchstone"
-version = "0.11.2"
+version = "0.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0a6176546c3d5094fccf8f4fe846293d5a3dd8f73df213554d3ff5f2c7a7ad6"
+checksum = "fab460d9e9df07f00f8418c01250b18d4762bd64588b8ff8e360beaee2ad3193"
 dependencies = [
  "rfconversions",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,15 +7,15 @@ homepage = "https://github.com/iancleary/gainlineup"
 license = "MIT"
 name = "gainlineup"
 repository = "https://github.com/iancleary/gainlineup"
-version = "0.20.2"
+version = "0.20.3"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-rfconversions = "0.6.0"
+rfconversions = "0.7.0"
 serde = { version = "1.0", features = ["derive"] }
 toml = "0.9.8"
-touchstone = "0.11.2"
+touchstone = "0.11.4"
 
 [features]
 default = ["cli", "plot"]


### PR DESCRIPTION
- rfconversions 0.6.0 → 0.7.0 (Friis cascade noise functions)
- touchstone 0.11.2 → 0.11.4 (rustdoc improvements)
- gainlineup 0.20.2 → 0.20.3
- All 157 tests pass