### PR TITLE
Add deterministic release process

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,9 +10,18 @@ Rust crate for RF signal chain (gain lineup) cascade analysis. Models amplifiers
 cargo test                        # Run all 96 tests (v0.22.2)
 cargo clippy -- -D warnings       # Lint
 cargo fmt -- --check              # Format check
+scripts/cut-release.sh --dry-run --version <semver> --notes-file <path>  # Preview release
 cargo run -- files/wideband.toml  # CLI: cascade from TOML, generates HTML
 cargo doc --open                  # Generate and view API docs
 ```
+
+## Releases
+
+Maintain the deterministic release workflow with `create-release-process`.
+Execute ordinary releases with `cut-release` via `scripts/cut-release.sh`; see
+`docs/release.md` for the repo-local contract. The runner requires an explicit
+SemVer `--version`, supports read-only version queries, and creates the GitHub
+release as the final public step of a real release.
 
 ## Module Map
 

--- a/docs/release.md
+++ b/docs/release.md
@@ -1,0 +1,55 @@
+# Release Process
+
+This repo has a deterministic local release runner at `scripts/cut-release.sh`.
+
+## Versioning
+
+The crate version is SemVer and lives in the root `Cargo.toml`. The next version
+is not inferred because the repo has no checked-in bump policy. Pass the intended
+version explicitly with `--version`.
+
+Read-only queries:
+
+```bash
+scripts/cut-release.sh --print-current-version
+scripts/cut-release.sh --print-next-version --version 0.22.3
+```
+
+## Dry Run
+
+Dry-run mode must not mutate public state:
+
+```bash
+scripts/cut-release.sh --dry-run --version 0.22.3 --notes-file /tmp/gainlineup-notes.md
+```
+
+The dry run prints the manifest, validation, commit, tag, push, and GitHub
+release actions that a real run would perform. It does not edit files, create
+commits, create tags, push, or create a GitHub release.
+
+## Real Release
+
+Prepare release notes in a local markdown file, then run from the default branch
+with a clean working tree:
+
+```bash
+scripts/cut-release.sh --version 0.22.3 --notes-file /tmp/gainlineup-notes.md
+```
+
+The runner updates `Cargo.toml` and `Cargo.lock`, runs:
+
+```bash
+cargo fmt -- --check
+cargo clippy --all-targets --all-features -- -D warnings
+cargo test
+```
+
+It then commits `chore: release v<version>`, creates an annotated `v<version>`
+tag, pushes the branch and tag, and finally creates the GitHub release with
+`gh release create`. The runner does not publish to crates.io; handle any crate
+publishing as a separate, explicit step.
+
+## Agent Routing
+
+Use `create-release-process` when maintaining this workflow. Use `cut-release`
+when executing an ordinary release request through the checked-in runner.

--- a/scripts/cut-release.sh
+++ b/scripts/cut-release.sh
@@ -1,0 +1,173 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'USAGE'
+Usage:
+  scripts/cut-release.sh --print-current-version
+  scripts/cut-release.sh --print-next-version --version <semver>
+  scripts/cut-release.sh --dry-run --version <semver> [--notes-file <path>]
+  scripts/cut-release.sh --version <semver> --notes-file <path>
+
+This crate uses SemVer from the root Cargo.toml. The next version is not
+inferred because the repo has no checked-in bump policy; pass --version.
+USAGE
+}
+
+dry_run=0
+print_current=0
+print_next=0
+version=""
+notes_file=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --dry-run)
+      dry_run=1
+      shift
+      ;;
+    --print-current-version)
+      print_current=1
+      shift
+      ;;
+    --print-next-version)
+      print_next=1
+      shift
+      ;;
+    --version)
+      version="${2:-}"
+      shift 2
+      ;;
+    --notes-file)
+      notes_file="${2:-}"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "error: unknown argument: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+repo_root="$(git rev-parse --show-toplevel)"
+cd "$repo_root"
+
+package_name="$(cargo metadata --no-deps --format-version 1 | python3 -c 'import json,sys; print(json.load(sys.stdin)["packages"][0]["name"])')"
+current_version="$(cargo metadata --no-deps --format-version 1 | python3 -c 'import json,sys; print(json.load(sys.stdin)["packages"][0]["version"])')"
+
+if [[ "$print_current" == 1 ]]; then
+  echo "$current_version"
+  exit 0
+fi
+
+if [[ "$print_next" == 1 ]]; then
+  if [[ -z "$version" ]]; then
+    echo "error: next-version inference is unsafe for this repo; pass --version <semver>" >&2
+    exit 2
+  fi
+  echo "$version"
+  exit 0
+fi
+
+if [[ -z "$version" ]]; then
+  echo "error: --version <semver> is required; this repo does not infer the next SemVer bump" >&2
+  exit 2
+fi
+
+if [[ ! "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+([+-][0-9A-Za-z.-]+)?$ ]]; then
+  echo "error: --version must be a SemVer value like 1.2.3" >&2
+  exit 2
+fi
+
+tag="v$version"
+
+if [[ "$dry_run" == 0 && -z "$notes_file" ]]; then
+  echo "error: --notes-file is required for a real release" >&2
+  exit 2
+fi
+
+if [[ -n "$notes_file" && ! -f "$notes_file" ]]; then
+  echo "error: notes file not found: $notes_file" >&2
+  exit 2
+fi
+
+if [[ "$version" == "$current_version" ]]; then
+  echo "error: target version matches current version ($current_version)" >&2
+  exit 2
+fi
+
+git fetch --tags origin
+if git rev-parse -q --verify "refs/tags/$tag" >/dev/null; then
+  echo "error: tag already exists: $tag" >&2
+  exit 2
+fi
+
+default_branch="$(git symbolic-ref --short refs/remotes/origin/HEAD 2>/dev/null | sed 's#^origin/##')"
+if [[ -z "$default_branch" ]]; then
+  default_branch="$(git remote show origin | sed -n '/HEAD branch/s/.*: //p')"
+fi
+current_branch="$(git branch --show-current)"
+
+if [[ "$dry_run" == 0 && "$current_branch" != "$default_branch" ]]; then
+  echo "error: release must run from default branch ($default_branch); current branch is $current_branch" >&2
+  exit 2
+fi
+
+if [[ "$dry_run" == 0 && -n "$(git status --porcelain)" ]]; then
+  echo "error: working tree must be clean before cutting a release" >&2
+  exit 2
+fi
+
+if [[ "$dry_run" == 1 ]]; then
+  echo "Dry run for $package_name $current_version -> $version"
+  if [[ "$current_branch" != "$default_branch" ]]; then
+    echo "Warning: real release must run from default branch ($default_branch); current branch is $current_branch"
+  fi
+  if [[ -n "$(git status --porcelain)" ]]; then
+    echo "Warning: real release requires a clean working tree"
+  fi
+  echo "Would update Cargo.toml and Cargo.lock"
+  echo "Would run: cargo fmt -- --check"
+  echo "Would run: cargo clippy --all-targets --all-features -- -D warnings"
+  echo "Would run: cargo test"
+  echo "Would commit: chore: release $tag"
+  echo "Would tag: $tag"
+  echo "Would push branch and tag to origin"
+  if [[ -n "$notes_file" ]]; then
+    echo "Would create GitHub release with notes from: $notes_file"
+  else
+    echo "Would require --notes-file before creating the GitHub release"
+  fi
+  exit 0
+fi
+
+python3 - "$version" <<'PY'
+import pathlib
+import re
+import sys
+
+version = sys.argv[1]
+path = pathlib.Path("Cargo.toml")
+text = path.read_text()
+updated, count = re.subn(r'(?m)^version = "[^"]+"$', f'version = "{version}"', text, count=1)
+if count != 1:
+    raise SystemExit("error: could not find a single package version in Cargo.toml")
+path.write_text(updated)
+PY
+
+cargo check
+cargo fmt -- --check
+cargo clippy --all-targets --all-features -- -D warnings
+cargo test
+
+git add Cargo.toml Cargo.lock
+git commit -m "chore: release $tag"
+git tag -a "$tag" -m "$tag"
+git push origin "$current_branch"
+git push origin "$tag"
+gh release create "$tag" --title "$tag" --notes-file "$notes_file"


### PR DESCRIPTION
## Summary
- Add a repo-local `scripts/cut-release.sh` runner for deterministic SemVer releases.
- Document release maintenance/execution in `docs/release.md` and `CLAUDE.md`.
- Keep the entrypoint script-based because this repo has no existing justfile or task runner convention.

## Checks run
- `bash -n scripts/cut-release.sh` passed.
- `scripts/cut-release.sh --print-current-version` printed `0.22.2`.
- `scripts/cut-release.sh --print-next-version --version 0.22.3` printed `0.22.3`.
- `GIT_SSH_COMMAND='ssh -i ~/.ssh/github_id_ed25519 -o IdentitiesOnly=yes' scripts/cut-release.sh --dry-run --version 0.22.3` passed and made no public mutations.
- `CARGO_TARGET_DIR=/home/iancleary/.openclaw/workspace/cargo-targets/gainlineup cargo clippy --all-targets --all-features -- -D warnings` passed.
- `CARGO_TARGET_DIR=/home/iancleary/.openclaw/workspace/cargo-targets/gainlineup cargo test` passed.
- `cargo fmt -- --check` failed on pre-existing formatting diffs in `src/block.rs`, `src/cli.rs`, `src/input.rs`, `src/node.rs`, and `tests/cross_crate_cascade_validation.rs`.

## Notes/risks
- The runner intentionally requires `--version`; this repo has SemVer tags but no checked-in policy for inferring the next bump.
- A real release requires `--notes-file` and creates the GitHub release as the final public step.
- The runner does not publish to crates.io; crate publishing remains a separate explicit step.
- Current formatting issues mean the release runner's validation will fail until the repo is formatted or the validation contract is intentionally changed.
