### PR TITLE
chore: disable root example autodiscovery

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ readme = "README.md"
 repository = "https://github.com/iancleary/gainlineup"
 rust-version = "1.85"
 version = "0.22.3"
+autoexamples = false
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 


### PR DESCRIPTION
## Summary

- Disable Cargo's automatic example target discovery for the root crate.
- Keeps the standalone `examples/` crate tree from being treated as packaged root examples during `cargo package`.
- Removes the package warning about `examples/src/main.rs` being ignored because it is not included in the published crate package.

## Checks run

- `just check`

## Notes / risks

- This does not remove or change the standalone examples tree.
- Root crate package contents remain the same size/count after the change, but `cargo package` no longer reports the ignored auto-discovered example warning.
